### PR TITLE
Removing std out output from TestHandler

### DIFF
--- a/meter/handler_test.go
+++ b/meter/handler_test.go
@@ -3,7 +3,6 @@
 package meter
 
 import (
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -26,7 +25,6 @@ func (handler *TestHandler) init() {
 
 func (handler *TestHandler) HandleMeters(values map[string]float64) {
 	handler.Init()
-	fmt.Printf("handler.handle: %v\n", values)
 	handler.valuesC <- values
 }
 
@@ -37,16 +35,13 @@ func (handler *TestHandler) Get() map[string]float64 {
 
 	select {
 	case values := <-handler.valuesC:
-		fmt.Printf("handler.get: %v\n", values)
 		return values
 
 	case <-timeoutC:
-		fmt.Printf("handler.get: timeout\n")
 		return nil
 	}
 }
 
 func (handler *TestHandler) Expect(title string, exp map[string]float64) {
 	CheckValues(handler.T, title, handler.Get(), exp)
-	fmt.Printf("handler.expect: %s\n\n", title)
 }


### PR DESCRIPTION
`fmt.printf()` is not safe and therefore must not be done from goroutines.